### PR TITLE
nan 1.5 for io.js support

### DIFF
--- a/.dntrc
+++ b/.dntrc
@@ -2,9 +2,11 @@
 ## see https://github.com/rvagg/dnt
 
 NODE_VERSIONS="\
-  v0.8.28      \
   v0.10.31     \
   v0.11.13     \
+"
+IOJS_VERSIONS="\
+  v1.0.1-release \
 "
 OUTPUT_PREFIX="leveldown-"
 TEST_CMD="\

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "abstract-leveldown": "~2.0.0",
     "bindings": "~1.2.1",
     "fast-future": "~1.0.0",
-    "nan": "~1.3.0"
+    "nan": "~1.5.0"
   },
   "devDependencies": {
     "du": "~0.1.0",


### PR DESCRIPTION
```
node@v0.11.13: PASS wrote output to /tmp/leveldown-dnt-v0.11.13.out
node@v0.10.31: PASS wrote output to /tmp/leveldown-dnt-v0.10.31.out
iojs@v1.0.1-release: PASS wrote output to /tmp/leveldown-dnt-v1.0.1-release.out
```