### PR TITLE
N on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,30 @@
-language: node_js
-node_js:
-  - "0.10"
-branches:
-  only:
-    - master
+language: c
+
+before_install:
+  - rm -rf ~/.nvm
+  - wget https://raw.githubusercontent.com/visionmedia/n/master/bin/n -qO n
+  - chmod +x n
+  - sudo cp n /usr/local/bin/n
+  - sudo chmod -R a+xw /usr/local
+  - n --version
+
+script:
+  - n 0.10
+  - node -v; which node; npm -v; which npm
+  - JOBS=max npm install
+  - npm test && rm -rf node_modules/
+
+  - n latest
+  - node -v; which node; npm -v; which npm
+  - JOBS=max npm install
+  - npm test && rm -rf node_modules/
+
+  - n io latest
+  - iojs -v; which iojs; npm -v; which npm
+  - JOBS=max npm install
+  - npm test
+
 notifications:
   email:
     - rod@vagg.org
-script: npm test
-
-before_install:
-  - npm install -g npm@latest
-
+    - ralphtheninja@riseup.net

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,17 @@ before_install:
 script:
   - n 0.10
   - node -v; which node; npm -v; which npm
-  - JOBS=max npm install
+  - npm install
   - npm test && rm -rf node_modules/
 
   - n latest
   - node -v; which node; npm -v; which npm
-  - JOBS=max npm install
+  - npm install
   - npm test && rm -rf node_modules/
 
   - n io latest
   - iojs -v; which iojs; npm -v; which npm
-  - JOBS=max npm install
+  - npm install
   - npm test
 
 notifications:

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
     "tap": "~0.4.12"
   },
   "scripts": {
-    "test": "tap test/*-test.js --stderr"
+    "test": "tap test/*-test.js --stderr",
+    "preinstall": "true",
+    "postinstall": "JOBS=max node-gyp rebuild"
   },
   "license": "MIT",
   "gypfile": true


### PR DESCRIPTION
So basically use `n` instead of  `nvm` to install the node versions we really need. Also, this wraps up all testing into one session, so don't have to wait for a new machine to boot up, just a waste of time. We basically only want to do `npm i && npm test` for different combinations of `node/iojs` and that's it.

See https://github.com/rvagg/node-leveldown/pull/154 for reference.